### PR TITLE
apply tags based on (some) container labels

### DIFF
--- a/dl_lib.py
+++ b/dl_lib.py
@@ -103,6 +103,13 @@ def get_container_env_vars(container):
     return env_tags
 
 
+def get_container_labels(container):
+    label_tags = {}
+    if docker_cli.inspect_container(container)['Config']['Labels'] is not None:
+        label_tags = docker_cli.inspect_container(container)['Config']['Labels']
+    return label_tags
+
+
 def get_container_id(path):
     if 'system.slice/docker-' in path:
         return path.replace('/system.slice/docker-', '')[:12]

--- a/tag.py
+++ b/tag.py
@@ -48,6 +48,7 @@ def get_tags(ctx, container_path):
     tags += container_image(container)
     tags += contain_env_vars(container)
     tags += container_host_name()
+    tags += container_labels(container)
 
     return tags
 
@@ -72,6 +73,19 @@ def contain_env_vars(container):
         if var in env_vars:
             env_var_tags += [env_vars[var]]
     return env_var_tags
+
+
+def container_labels(container):
+    def no_dot(label):
+        return '.' not in label
+
+    container_id = dl_lib.get_container_id(container['name'])
+    labels = dl_lib.get_container_labels(container_id)
+    labels_to_tag = filter(no_dot, labels)
+    label_tags = []
+    for var in labels_to_tag:
+        label_tags += [labels[var]]
+    return label_tags
 
 
 def container_host_name():


### PR DESCRIPTION
Restrict to simple labels (without '.' in them) in order to exclude any labels
that may have been applied implicitly by docker/swarm.